### PR TITLE
Defined about page url and emboldened metadata fields in about page

### DIFF
--- a/application.py
+++ b/application.py
@@ -436,6 +436,23 @@ def metadata():
 def feedback():
     return render_template('feedback.html')
 
+# About Page
+@application.route('/about')
+def about():
+    resp = make_response(render_template('about.html'))
+
+    # Set cookie data if not found
+    if not request.cookies.get('user_id'):
+        expire_date = datetime.datetime.now() + datetime.timedelta(days=90)
+        g_uuid = str(uuid.uuid4())
+
+    # Log query
+    application.logger.info("[{}] {} looked at the about page.".format(epochalypse_now(), request.cookies.get('user_id')))
+
+    # Render about page
+
+    return resp
+
 # Main page
 # Also, set a unique ID for this user
 @application.route('/')

--- a/templates/about.html
+++ b/templates/about.html
@@ -6,22 +6,21 @@
         <div class="col-md-12">
             <div class="page-header"><h2>Available Fragile Families Metadata</h2></div>
             <p class="lead">Descriptions of the available metadata:</p>
-            <p>old_name: Corresponds to what the variable was named before the re-release of February 2018.</p>
-            <p>new_name: Corresponds to what the variable was named after the re-release of February 2018 .</p>
-            <p>varlab: A description of the variable, generated from the variable label in the Stata version of the data.</p>
-            <p>type: Describes the way the data is stored. Can be one of five categories: Binary (bin), Continuous (cont), Unordered Categorical (uc), Ordered Catergorical (oc) or String (string).</p>
-						<p>group: Links the variable to similar variables in other instruments.</p>
-						<p>q_group_N: The number of similar variables in the given variables group.</p>
-						<p>topic[1,2]: A tag that describes the specific concept measured by the variable.</p>
-						<p>umbrella[1,2]: A more general tag describing the concept measured by the variable.</p>
-						<p>scope: An indicator of how many cities were asked the question corresponding to this variable. </p>
-						<p>warning: An indicator that this variable may have data stored in a way that would be unusual given its type.</p>
-						<p>source: The original source of the data, i.e questionnaire, constructed variable, etc.</p>
-						<p>respondent: The focus of the source, i.e. father/mother/PCG/. Generated from the varname. </p>
-						<p>wave: Which wave of data collection the variable comes from. Generated from the varname. </p>
-						<p>section: Which section of the instrument the variable comes from. Generated from the varname. </p>
-						<p>leaf: The question number or short descriptor, depending on the source. Generated from the varname. </p>
-						<p>q_group_list: A string list seperated by spaces, containing all of the names of similar variables. </p>
+            <p><b>new_name</b>: Corresponds to what the variable was named after the re-release of February 2018 .</p>
+            <p><b>varlab</b>: A description of the variable, generated from the variable label in the Stata version of the data.</p>
+            <p><b>type</b>: Describes the way the data is stored. Can be one of five categories: Binary (bin), Continuous (cont), Unordered Categorical (uc), Ordered Catergorical (oc) or String (string).</p>
+						<p><b>group</b>: Links the variable to similar variables in other instruments.</p>
+						<p><b>q_group_N</b>: The number of similar variables in the given variables group.</p>
+						<p><b>topic[1,2]</b>: A tag that describes the specific concept measured by the variable.</p>
+						<p><b>umbrella[1,2]</b>: A more general tag describing the concept measured by the variable.</p>
+						<p><b>scope</b>: An indicator of how many cities were asked the question corresponding to this variable. </p>
+						<p><b>warning</b>: An indicator that this variable may have data stored in a way that would be unusual given its type.</p>
+						<p><b>source</b>: The original source of the data, i.e questionnaire, constructed variable, etc.</p>
+						<p><b>respondent</b>: The focus of the source, i.e. father/mother/PCG/. Generated from the varname. </p>
+						<p><b>wave</b>: Which wave of data collection the variable comes from. Generated from the varname. </p>
+						<p><b>section</b>: Which section of the instrument the variable comes from. Generated from the varname. </p>
+						<p><b>leaf</b>: The question number or short descriptor, depending on the source. Generated from the varname. </p>
+						<p><b>q_group_list</b>: A string list seperated by spaces, containing all of the names of similar variables. </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Thanks to @atkindel, about page now runs smoothly. also added tags to make the names of the metadata fields bold and easier to distinguish. Should close issue #8