### PR TITLE
Added tooltips to search page

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -85,13 +85,13 @@
                         <table id="results" class="table table-hover">
                             <thead>
                                 <tr>
-                                    <th>Variable</th>
+                                    <th data-toggle="tooltip" data-placement="top" title="Name in the data file">Variable</th>
                                     <th>Description</th>
-                                    <th>Topics</th>
-                                    <th>Respondent</th>
-                                    <th>Wave</th>
-                                    <th>Type</th>
-                                    <th>Source</th>
+                                    <th data-toggle="tooltip" data-placement="top" title="Specific concept measured">Topics</th>
+                                    <th data-toggle="tooltip" data-placement="top" title="Who was asked the question">Respondent</th>
+                                    <th data-toggle="tooltip" data-placement="top" title="The wave of data collection">Wave</th>
+                                    <th data-toggle="tooltip" data-placement="top" title="Storage type">Type</th>
+                                    <th data-toggle="tooltip" data-placement="top" title="How the data was gathered">Source</th>
                                 </tr>
                             </thead>
                             <tbody>


### PR DESCRIPTION
issue #32 should be closed, unless we want any aesthetic changes to the tooltips. I tried adding the tooltips to the similar variables table in variable.html, but it caused a weird formatting glitch to occur when I hovered over them. 