### PR TITLE
Change the formatting of the filters on the Browse page to increase visibility

### DIFF
--- a/ffmeta/blueprints/web.py
+++ b/ffmeta/blueprints/web.py
@@ -71,11 +71,6 @@ def search():
     if request.method == "POST":
         query = session.query(Variable)
 
-        # Filter by search query
-        search_query = request.form["variable-search"]
-        if len(search_query) > 0:
-            query = query.filter(Variable.label.like('%%{}%%'.format(search_query)) | Variable.name.like('%%{}%%'.format(search_query)) | Variable.old_name.like('%%{}%%'.format(search_query)))
-
         # Filter by fields
         constraints = dict()
         for field in set(valid_filters.keys()).intersection(request.form.keys()):
@@ -105,8 +100,9 @@ def search():
         variable_names = [result.name for result in results]
         zero_found = len(variable_names) == 0
 
-    resp = make_response(render_template('web/search.html', results=results, rnames=variable_names, constraints=constraints,
-                           search_query=search_query, filtermeta=valid_filters, filterlabs=filter_labels, zero_found=zero_found))
+    resp = make_response(render_template('web/search.html', results=results, rnames=variable_names,
+                                         constraints=constraints, filtermeta=valid_filters, filterlabs=filter_labels,
+                                         zero_found=zero_found))
 
     return resp
 

--- a/ffmeta/blueprints/web.py
+++ b/ffmeta/blueprints/web.py
@@ -13,16 +13,20 @@ bp = Blueprint('web', __name__)
 
 # Define valid search filters
 # This object determines what filter groups show up in the search view
-filter_labels = OrderedDict([
-    ("topic", "Topic"),
-    ("wave", "Wave"),
-    ("respondent", "Respondent"),
-    ("data_source", "Source"),
-    ("data_type", "Variable type"),
-    ("measures", "Scales"),
-    ("survey", "Survey"),
-    ("focal_person", "Focal Person")
-])
+filter_labels = [
+    OrderedDict([
+        ("topic", "Topic"),
+        ("wave", "Wave"),
+        ("respondent", "Respondent"),
+        ("focal_person", "Focal Person")
+    ]),
+    OrderedDict([
+        ("measures", "Scales"),
+        ("survey", "Survey"),
+        ("data_source", "Source"),
+        ("data_type", "Variable type")
+    ])
+]
 
 # Define domain-label map for each filter
 # This defines what values are valid to filter on for each filter group

--- a/ffmeta/templates/web/search.html
+++ b/ffmeta/templates/web/search.html
@@ -30,28 +30,19 @@ $(document).ready(function() {
     <div class="container">
         <div class="row">
             <div class="col-md-12">
-                <h2>Search variables</h2>
+                <h2>Browse variables</h2>
                 <p></p>
                 <hr>
             </div>
         </div>
         <div class="row">
-            <div class="col-md-3">
+            <div class="col-md-12">
                 <form action="{{ url_for('web.search')}}" method="POST">
-                    <div class="form-group">
-                        <div class="input-group">
-                            <input type="search-term" class="form-control" name="variable-search" placeholder="Search for..." {% if search_query %} value="{{ search_query }}" {% endif %}>
-                            <span class="input-group-btn">
-                                <button type="submit" class="btn btn-default">Search &#187;</button>
-                            </span>
-                        </div>
-                    </div>
-
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <h4 class="panel-title">
                                 <a role="button" data-toggle="collapse" href="#collapse_filter">
-                                    Filter
+                                    Filters
                                 </a>
                             </h4>
                         </div>
@@ -78,14 +69,20 @@ $(document).ready(function() {
                             </div>
                         </div>
                     </div>
-
+                    <div>
+                        <span class="input-group-btn">
+                            <button type="submit" class="btn btn-default">Submit &#187;</button>
+                        </span>
+                    </div>
                 </form>
 
 
             </div>
-            <div class="col-md-9">
 
-                {% if results %}
+        </div>
+        {% if results %}
+        <div class="row">
+            <div class="col-md-12">
 
                 <!-- Display search results -->
                 <div class="panel panel-default">
@@ -154,10 +151,9 @@ $(document).ready(function() {
                     </div>
                 </div>
 
-                {% endif %}
-
             </div>
         </div>
+        {% endif %}
     </div>
 {% endblock %}
 

--- a/ffmeta/templates/web/search.html
+++ b/ffmeta/templates/web/search.html
@@ -35,7 +35,7 @@ $(document).ready(function() {
                 <hr>
             </div>
         </div>
-        <div class="row">
+        <div class="row" style="margin-bottom: 20px;">
             <div class="col-md-12">
                 <form action="{{ url_for('web.search')}}" method="POST">
                     <div class="panel panel-default">
@@ -48,23 +48,29 @@ $(document).ready(function() {
                         </div>
                         <div id="collapse_filter" class="panel-collapse collapse in" role="tabpanel">
                             <div class="panel-body">
-                                {% for filt, desc in filterlabs.items() %}
-                                <div class="panel panel-default">
-                                    <div class="panel-heading" data-toggle="collapse" href="#collapse_{{filt}}">
-                                        <a role="button">
-                                            {{desc}}
-                                        </a>
-                                    </div>
-                                    <div id="collapse_{{filt}}" class="panel-collapse collapse {{isin(filt)}}" role="tabpanel">
-                                        <div class="panel-body">
-                                            <select class="select2" name="{{filt}}" multiple="multiple" style="width: 100%">
-                                            {% for val, lab in filtermeta[filt].items() %}
-                                                <option value="{{val}}" {{selected(val, filt)}}>{{lab}}</option>
-                                            {% endfor %}
-                                            </select>
+                                {% for f in filterlabs %}
+                                    <div class = "row">
+                                      {% for filt, desc in f.items() %}
+                                        <div class="col-md-3">
+                                            <div class="panel panel-default">
+                                                <div class="panel-heading" data-toggle="collapse" href="#collapse_{{filt}}">
+                                                    <a role="button">
+                                                        {{desc}}
+                                                    </a>
+                                                </div>
+                                                <div id="collapse_{{filt}}" class="panel-collapse collapse {{isin(filt)}}" role="tabpanel">
+                                                    <div class="panel-body">
+                                                        <select class="select2" name="{{filt}}" multiple="multiple" style="width: 100%">
+                                                        {% for val, lab in filtermeta[filt].items() %}
+                                                            <option value="{{val}}" {{selected(val, filt)}}>{{lab}}</option>
+                                                        {% endfor %}
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </div>
+                                      {% endfor %}
                                     </div>
-                                </div>
                                 {% endfor %}
                             </div>
                         </div>
@@ -105,7 +111,7 @@ $(document).ready(function() {
                             <tbody>
                                 {% for result in results %}
                                 <tr>
-                                    <td><a type="button" class="btn btn-primary" href="{{ url_for('web.var_page', varname = result.name) }}">{{result.name}}</button></td>
+                                    <td><a type="button" class="btn btn-primary" href="{{ url_for('web.var_page', varname = result.name) }}">{{result.name}}</a></td>
                                     <td>{{result.label}}</td>
                                     <td><small>{{result.topics}}</small></td>
                                     <td><small>{{filtermeta.survey[result.survey]}}</small></td>
@@ -129,14 +135,6 @@ $(document).ready(function() {
                         <a href="{{ url_for('web.search') }}" role="button" class="btn btn-danger"><span class="oi" data-glyph="trash"></span> Start over </a>
                     </div>
                 </div>
-
-                {% else %}
-
-                <p>To search variables and view associated metadata online, use the search options on the left.</p>
-                <p>To query the metadata programmatically, click <em>Metadata API</em>.</p>
-                <p>To download metadata for all variables as a CSV file, click <em>Download metadata</em>.</p>
-                <p>If you have any comments or ideas for how to improve the metadata or this app, click <em>Feedback</em>.</p>
-                <p>To learn more about the Fragile Families and Child Wellbeing Study, click <em>About FFCWS</em>.</p>
 
                 {% endif %}
 

--- a/ffmeta/templates/web/variable.html
+++ b/ffmeta/templates/web/variable.html
@@ -81,14 +81,16 @@
                 </div>
                 <div id="collapse_filter" class="panel-collapse collapse in" role="tabpanel">
                     <div class="panel-body">
-                        {% for filt, desc in filterlabs.items() %}
-                            {% if filt not in ("topic", "measures", "survey") %}
-                                {% for val, lab in filtermeta[filt].items() %}
-                                    {% if var_data[filt] == val %}
-                                        <span class="label label-default label-metadata" data-toggle="tooltip" data-placement="left" title="{{desc}}">{{lab}}</span><br/><br/>
-                                    {% endif %}
-                                {% endfor %}
-                            {% endif %}
+                        {% for f in filterlabs %}
+                            {% for filt, desc in f.items() %}
+                                {% if filt not in ("topic", "measures", "survey") %}
+                                    {% for val, lab in filtermeta[filt].items() %}
+                                        {% if var_data[filt] == val %}
+                                            <span class="label label-default label-metadata" data-toggle="tooltip" data-placement="left" title="{{desc}}">{{lab}}</span><br/><br/>
+                                        {% endif %}
+                                    {% endfor %}
+                                {% endif %}
+                            {% endfor %}
                         {% endfor %}
                         <b>About: </b>
                         {{ var_data.focal_people_string() }}


### PR DESCRIPTION
Reformatted the filters in two rows of four at the top of the page, and removed the search bar. This should make the filters that were at the bottom of the page more visible to the users. Closes issue #81 